### PR TITLE
ipq40xx: fix dtc warning (#4660)

### DIFF
--- a/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-4.14/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
@@ -114,7 +114,7 @@
 	led_spi {
 		compatible = "spi-gpio";
 		#address-cells = <1>;
-		ranges;
+		#size-cells = <0>;
 
 		sck-gpios = <&tlmm 40 GPIO_ACTIVE_HIGH>;
 		mosi-gpios = <&tlmm 36 GPIO_ACTIVE_HIGH>;

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dts
@@ -114,7 +114,7 @@
 	led_spi {
 		compatible = "spi-gpio";
 		#address-cells = <1>;
-		ranges;
+		#size-cells = <0>;
 
 		sck-gpios = <&tlmm 40 GPIO_ACTIVE_HIGH>;
 		mosi-gpios = <&tlmm 36 GPIO_ACTIVE_HIGH>;

--- a/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-wpj419.dts
+++ b/target/linux/ipq40xx/files-4.19/arch/arm/boot/dts/qcom-ipq4019-wpj419.dts
@@ -151,8 +151,6 @@
 			num-cs = <2>;
 
 			flash0@0 {
-				#address-cells = <1>;
-				#size-cells = <1>;
 				reg = <0>;
 				compatible = "jedec,spi-nor";
 				spi-max-frequency = <24000000>;
@@ -160,6 +158,8 @@
 
 				partitions {
 					compatible = "fixed-partitions";
+					#address-cells = <1>;
+					#size-cells = <1>;
 
 					partition@0 {
 						label = "0:SBL1";
@@ -275,7 +275,7 @@
 		i2c_0: i2c@78b7000 {
 			pinctrl-0 = <&i2c_0_pins>;
 			pinctrl-names = "default";
-			status = "ok";
+			status = "okay";
 		};
 
 		serial@78af000 {


### PR DESCRIPTION
arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dtb: Warning (reg_format):
"reg" property in /led_spi/led_gpio@0 has invalid length (4 bytes)
(#address-cells == 1, #size-cells == 1)
arch/arm/boot/dts/qcom-ipq4019-cm520-79f.dtb: Warning
(avoid_default_addr_size): Relying on default #size-cells value for
/led_spi/led_gpio@0
arch/arm/boot/dts/qcom-ipq4019-wpj419.dtb: Warning (reg_format):
/soc/spi@78b5000/flash0@0/partitions/partition@0:reg: property has
invalid length (8 bytes) (#size-cells == 1)

Signed-off-by: AmadeusGhost <amadeus@jmu.edu.cn>

Q：你知道这是`pull request`吗？(使用 "x" 选择)
* [x] 我知道
